### PR TITLE
Enable easy control of SVG QR code colors and styles

### DIFF
--- a/qr.js
+++ b/qr.js
@@ -746,7 +746,7 @@ var QRCode = {
 		var margin = Math.max(options.margin !== null ? options.margin : 4, 0.0);
 		var size = modsize * (n + 2 * margin);
 
-		var common = ' class= "fg"'+' width="'+modsize+'" height="'+modsize+'"/>';
+		var common = ' class= "fg" part="module-fg"'+' width="'+modsize+'" height="'+modsize+'"/>';
 
 		var e = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
 		e.setAttribute('viewBox', '0 0 '+size+' '+size);
@@ -757,8 +757,8 @@ var QRCode = {
         }
 
 		var svg = [
-			'<style scoped>.bg{fill:#FFF}.fg{fill:#000}</style>',
-			'<rect class="bg" x="0" y="0"',
+			'<style scoped>.bg{fill:var(--qr--bg, #FFF)}.fg{fill:var(--qr--fg, #000)}</style>',
+			'<rect class="bg" part="module-bg" x="0" y="0"',
 			'width="'+size+'" height="'+size+'"/>',
 		];
 


### PR DESCRIPTION
Currently, when this library is used via `qr-code`, there's no way to override the colours or styles when in SVG mode. 

`part` attributes were previously added to the HTML table QR version, but not the SVG version which prevented any control over those elements when they were in the shadow DOM.

If the user only needs to control colours, it's simpler just to give them a CSS custom property to edit as CSS variables are inherited into the shadow DOM. I've added `--qr--fg` and `--qr--bg`.

- Add `part` attributes to generated foreground and background SVG elements.
- Add `--qr--fg` and `--qr--bg` CSS variables with fallbacks to inline SVG styles for easier control of the QR code colors

This issue mentioned a similar issue: https://github.com/educastellano/qr-code/issues/20

Thanks for the qr-code library! 👌